### PR TITLE
Update roc-lang/unicode to 0.1.2 and add imclerran/roc-isodate 0.5.0

### DIFF
--- a/bin/download-dependencies.roc
+++ b/bin/download-dependencies.roc
@@ -1,6 +1,7 @@
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
-    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.1/-FQDoegpSfMS-a7B0noOnZQs3-A2aq9RSOR5VVLMePg.tar.br",
+    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.2/vH5iqn04ShmqP-pNemgF773f86COePSqMWHzVGrAKNo.tar.br",
+    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.0/ptg0ElRLlIqsxMDZTTvQHgUSkNrUSymQaGwTfv0UEmk.tar.br",
 }
 
 import pf.Task exposing [Task]


### PR DESCRIPTION
The `unicode` package is used in the `reverse-string` exercise, to split Unicode graphemes properly. The update is needed to get rid of pesky deprecation warnings.
The `isodate` package is used in the `gigasecond` exercise, to handle dates properly.
